### PR TITLE
fix bugtracking information

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,9 @@ my %wm = (
 		"url"	=> "https://github.com/CPAN-Security/Test-CVE.git",
 		"web"	=> "https://github.com/CPAN-Security/Test-CVE",
 		},
+	    bugtracker	=> {
+		"web"	=> "https://github.com/CPAN-Security/Test-CVE/issues",
+		},
 	    },
 	},
     );


### PR DESCRIPTION
Without explicit bugracker link information, MetaCPAN will default to RT. This patch fixes that.